### PR TITLE
Replace md5 usage with sha256

### DIFF
--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -1,7 +1,7 @@
 import logging
 import re
 import struct
-from hashlib import sha256, md5, sha384, sha512
+from hashlib import sha256, sha384, sha512
 from typing import (Any, Callable, Dict, Iterable, Iterator, KeysView, List,
                     Optional, Sequence, Tuple, Type, Union, cast)
 
@@ -366,7 +366,7 @@ class PDFStandardSecurityHandler:
             return Arcfour(key).encrypt(self.PASSWORD_PADDING)  # 2
         else:
             # Algorithm 3.5
-            hash = md5(self.PASSWORD_PADDING)  # 2
+            hash = sha256(self.PASSWORD_PADDING)  # 2
             hash.update(self.docid[0])  # 3
             result = Arcfour(key).encrypt(hash.digest())  # 4
             for i in range(1, 20):  # 5
@@ -378,7 +378,7 @@ class PDFStandardSecurityHandler:
     def compute_encryption_key(self, password: bytes) -> bytes:
         # Algorithm 3.2
         password = (password + self.PASSWORD_PADDING)[:32]  # 1
-        hash = md5(password)  # 2
+        hash = sha256(password)  # 2
         hash.update(self.o)  # 3
         # See https://github.com/pdfminer/pdfminer.six/issues/186
         hash.update(struct.pack('<L', self.p))  # 4
@@ -391,7 +391,7 @@ class PDFStandardSecurityHandler:
         if self.r >= 3:
             n = self.length // 8
             for _ in range(50):
-                result = md5(result[:n]).digest()
+                result = sha256(result[:n]).digest()
         return result[:n]
 
     def authenticate(self, password: str) -> Optional[bytes]:
@@ -418,10 +418,10 @@ class PDFStandardSecurityHandler:
     def authenticate_owner_password(self, password: bytes) -> Optional[bytes]:
         # Algorithm 3.7
         password = (password + self.PASSWORD_PADDING)[:32]
-        hash = md5(password)
+        hash = sha256(password)
         if self.r >= 3:
             for _ in range(50):
-                hash = md5(hash.digest())
+                hash = sha256(hash.digest())
         n = 5
         if self.r >= 3:
             n = self.length // 8
@@ -448,7 +448,7 @@ class PDFStandardSecurityHandler:
         assert self.key is not None
         key = self.key + struct.pack('<L', objid)[:3] \
             + struct.pack('<L', genno)[:2]
-        hash = md5(key)
+        hash = sha256(key)
         key = hash.digest()[:min(len(key), 16)]
         return Arcfour(key).decrypt(data)
 
@@ -515,7 +515,7 @@ class PDFStandardSecurityHandlerV4(PDFStandardSecurityHandler):
         assert self.key is not None
         key = self.key + struct.pack('<L', objid)[:3] \
             + struct.pack('<L', genno)[:2] + b'sAlT'
-        hash = md5(key)
+        hash = sha256(key)
         key = hash.digest()[:min(len(key), 16)]
         initialization_vector = data[:16]
         ciphertext = data[16:]

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -348,7 +348,7 @@ class PDFStandardSecurityHandler:
     def init_key(self) -> None:
         self.key = self.authenticate(self.password)
         if self.key is None:
-            raise PDFPasswordIncorrect
+            raise Exception('PDFPasswordIncorrect: Missing key for password: %s' % self.password)
         return
 
     def is_printable(self) -> bool:

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -64,6 +64,10 @@ class PDFTextExtractionNotAllowed(PDFEncryptionError):
     pass
 
 
+class PDFPasswordIncorrect(PDFEncryptionError):
+    pass
+
+
 class PDFTextExtractionNotAllowedError(PDFTextExtractionNotAllowed):
     def __init__(self, *args: object) -> None:
         from warnings import warn
@@ -348,7 +352,7 @@ class PDFStandardSecurityHandler:
     def init_key(self) -> None:
         self.key = self.authenticate(self.password)
         if self.key is None:
-            raise Exception('PDFPasswordIncorrect: Missing key for password: %s' % self.password)
+            raise PDFPasswordIncorrect
         return
 
     def is_printable(self) -> bool:

--- a/pdfminer/pdfpage.py
+++ b/pdfminer/pdfpage.py
@@ -139,9 +139,11 @@ class PDFPage:
         caching: bool = True,
         check_extractable: bool = False
     ) -> Iterator["PDFPage"]:
+        # this is the key
         # Create a PDF parser object associated with the file object.
         parser = PDFParser(fp)
         # Create a PDF document object that stores the document structure.
+        # this is where things fail
         doc = PDFDocument(parser, password=password, caching=caching)
         # Check if the document allows text extraction.
         # If not, warn the user and proceed.

--- a/pdfminer/pdfpage.py
+++ b/pdfminer/pdfpage.py
@@ -139,11 +139,9 @@ class PDFPage:
         caching: bool = True,
         check_extractable: bool = False
     ) -> Iterator["PDFPage"]:
-        # this is the key
         # Create a PDF parser object associated with the file object.
         parser = PDFParser(fp)
         # Create a PDF document object that stores the document structure.
-        # this is where things fail
         doc = PDFDocument(parser, password=password, caching=caching)
         # Check if the document allows text extraction.
         # If not, warn the user and proceed.


### PR DESCRIPTION
**Pull request**

Thanks for improving pdfminer.six! Please include the following information to
help us discuss and merge this PR:

- A description of why this PR is needed. What does it fix? What does it 
  improve?
  - md5 cannot be used on SOAR FIPs instances. sha256 should work for FIPS and Non-FIPS instances.
  - Error message: `[digital envelope routines: EVP_DigestInit_ex] disabled for FIPS.`
  - This repo is used as a direct dependency for [Parser](https://github.com/splunk-soar-connectors/parser)

- A summary of the things that this PR changes.
  - Replace all md5 usages to sha256

- Reference the issues that this PR fixes (use the fixes #(issue nr) syntax). 
  If this PR does not fix any issue, create the issue first and mention that 
  you are willing to work on it.

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide 
instructions so we can reproduce. Include an example pdf if you have one. 

**Checklist**

- [ ] I have added tests that prove my fix is effective or that my feature 
  works
- [ ] I have added docstrings to newly created methods and classes
- [ ] I have optimized the code at least one time after creating the initial 
  version
- [ ] I have updated the [README.md](../README.md) or verified that this
  is not necessary
- [ ] I have updated the [readthedocs](../docs/source) documentation or
  verified that this is not necessary
- [ ] I have added a concise human-readable description of the change to
  [CHANGELOG.md](../CHANGELOG.md)
